### PR TITLE
Allow for single branch transactions

### DIFF
--- a/documentation/src/main/paradox/coordinator.md
+++ b/documentation/src/main/paradox/coordinator.md
@@ -5,9 +5,8 @@ trait Coordinator[F[_], TID, BID, Q, R]
   def create(
       id: TID,
       query: Q,
-      branch1: BID,
-      branch2: BID,
-      others: BID*
+      branch: BID,
+      otherBranches: BID*
   ): Resource[F, Transaction[F, BID, Q, R]]
 ```
 

--- a/example/src/test/scala/endless/transaction/example/logic/ShardedAccountsSuite.scala
+++ b/example/src/test/scala/endless/transaction/example/logic/ShardedAccountsSuite.scala
@@ -89,9 +89,8 @@ class ShardedAccountsSuite
       def create(
           id: TransferID,
           query: Transfer,
-          branch1: AccountID,
-          branch2: AccountID,
-          others: AccountID*
+          branch: AccountID,
+          otherBranches: AccountID*
       ): Resource[IO, Transaction[IO, AccountID, Transfer, TransferFailure]] =
         Resource.pure(new Transaction[IO, AccountID, Transfer, TransferFailure] {
           def query: IO[Transaction.Unknown.type \/ Transfer] = fail("should not be called")

--- a/lib/src/main/scala/endless/transaction/Coordinator.scala
+++ b/lib/src/main/scala/endless/transaction/Coordinator.scala
@@ -30,11 +30,9 @@ trait Coordinator[F[_], TID, BID, Q, R] {
     *   the transaction id
     * @param query
     *   the query to be executed (transaction payload)
-    * @param branch1
+    * @param branch
     *   the first branch
-    * @param branch2
-    *   the second branch
-    * @param others
+    * @param otherBranches
     *   the remaining branches
     * @return
     *   handle to the transaction
@@ -42,9 +40,8 @@ trait Coordinator[F[_], TID, BID, Q, R] {
   def create(
       id: TID,
       query: Q,
-      branch1: BID,
-      branch2: BID,
-      others: BID*
+      branch: BID,
+      otherBranches: BID*
   ): Resource[F, Transaction[F, BID, Q, R]]
 
   /** Recovers a transaction with the given id. Can be used by recovering clients who lost the

--- a/lib/src/main/scala/endless/transaction/impl/logic/ShardedCoordinator.scala
+++ b/lib/src/main/scala/endless/transaction/impl/logic/ShardedCoordinator.scala
@@ -38,15 +38,14 @@ private[transaction] final class ShardedCoordinator[F[_]: Logger, TID, BID, Q, R
   def create(
       id: TID,
       query: Q,
-      branch1: BID,
-      branch2: BID,
-      others: BID*
+      branch: BID,
+      otherBranches: BID*
   ): Resource[F, Transaction[F, BID, Q, R]] =
     Resource.eval(
       Logger[F].debug(show"Creating transaction $id") >>
         sharding
           .entityFor(id)
-          .create(id, query, NonEmptyList.of[BID](branch1, (branch2 +: others)*))
+          .create(id, query, NonEmptyList.of[BID](branch, otherBranches*))
     )
       >>= {
         case Right(_) =>

--- a/lib/src/test/scala/endless/transaction/impl/logic/ShardedCoordinatorSuite.scala
+++ b/lib/src/test/scala/endless/transaction/impl/logic/ShardedCoordinatorSuite.scala
@@ -116,7 +116,7 @@ class ShardedCoordinatorSuite
         }
       val coordinator = new ShardedCoordinator(sharding)
       coordinator
-        .create(tid, query, branches.head, branches.head, branches.tail*)
+        .create(tid, query, branches.head, branches.tail*)
         .use_ >> logger.assertLogsDebug
     }
   }
@@ -141,7 +141,7 @@ class ShardedCoordinatorSuite
       val coordinator = new ShardedCoordinator(sharding)
       interceptIO[Coordinator.TransactionAlreadyExists.type](
         coordinator
-          .create(tid, query, branches.head, branches.head, branches.tail*)
+          .create(tid, query, branches.head, branches.tail*)
           .use_
       ) >> logger.assertLogsDebug >> logger.assertLogsWarn
     }


### PR DESCRIPTION
This can be useful when describing a process using transaction entities, in some degraded cases