### PR TITLE
Make wrapping transaction into resource opt-in

### DIFF
--- a/documentation/src/main/paradox/2pc.md
+++ b/documentation/src/main/paradox/2pc.md
@@ -23,12 +23,12 @@ Some examples of commit operations in the same imaginary touristic journey booki
 
 | Example: orchestration of the booking process for a journey   | Data store         | Transaction branch operation          |
 |---------------------------------------------------------------|--------------------|---------------------------------------|
-| Do nothing: reservations were already made                    | External API       | -                                     |
-| Do nothing: the guarantee charge was already made             | Internal service   | -                                     |
+| Do nothing: reservations were already made                    | External API       | nop                                   |
+| Do nothing: the guarantee charge was already made             | Internal service   | nop                                   |
 | Update customer details in the internal database              | Database           | Perform the row update and unlock     |
 | Update the "recent bookings" cache and release the semaphore  | In-memory resource | Edit and unlock an in-memory resource |
-| Do nothing: the reminder notifications were already scheduled | Actor cluster      | -                                     |
-| Do nothing: the bookings log was already updated              | File               | -                                     |
+| Do nothing: the reminder notifications were already scheduled | Actor cluster      | nop                                   |
+| Do nothing: the bookings log was already updated              | File               | nop                                   |
 
 @@@ note { title="Commit consistency" }
 It's up to the implementer to decide the level of consistency in the execution of the commit. Transaction failure is also valid and can be signaled by raising an exception in the target effect. Failure will lead to inconsistency in the overall system state, which can be an acceptable

--- a/documentation/src/main/paradox/coordinator.md
+++ b/documentation/src/main/paradox/coordinator.md
@@ -12,7 +12,7 @@ trait Coordinator[F[_], TID, BID, Q, R]
 
 @scaladoc[Coordinator](endless.transaction.Coordinator) allows for creating and recovering transactions of a certain type. Internally, it implements the two-phase commit protocol to guarantee a final transaction state of either committed or aborted.
 
-The `create` method creates a new transaction with the given id, query and branches, and returns a `Transaction` wrapped in a `Resource`. Resource release leads to transaction abort if it is still pending (or a no-op if the transaction is already completed). 
+The `create` method creates a new transaction with the given id, query and branches, and returns a `Transaction` handle. 
 
 Parameters of `create` are:
 
@@ -24,4 +24,8 @@ Parameters of `create` are:
 Behavior for each branch is defined by the `branchForID` function passed to the `Coordinator` upon creation. This is invoked upon node restart for any pending transaction. It is therefore important to consider compatibility aspects if any change is done on this behavior. 
 
 The transaction might be in a partial preparation readiness state, and rollout of the new version will pick up preparation where it left off. As long as the new behavior is compatible with the old, this is not a problem. 
+@@@
+
+@@@ note { title=Resource }
+The `asResource` convenience implicit def will wrap the transaction instance into a `Resource`, with release leading to transaction abort if it is still pending (or a no-op if the transaction is already completed). 
 @@@

--- a/example/src/main/scala/endless/transaction/example/logic/ShardedAccounts.scala
+++ b/example/src/main/scala/endless/transaction/example/logic/ShardedAccounts.scala
@@ -29,6 +29,7 @@ final class ShardedAccounts[F[_]: Temporal: Logger](
   def transfer(from: AccountID, to: AccountID, amount: PosAmount): F[TransferFailure \/ Unit] =
     coordinator
       .create(TransferID.random, Transfer(from, to, amount), from, to)
+      .asResource
       .use(_.pollForFinalStatus())
       .flatMap {
         case Status.Committed => ().asRight[TransferFailure].pure

--- a/example/src/test/scala/endless/transaction/example/logic/ShardedAccountsSuite.scala
+++ b/example/src/test/scala/endless/transaction/example/logic/ShardedAccountsSuite.scala
@@ -2,7 +2,6 @@ package endless.transaction.example.logic
 
 import cats.data.NonEmptyList
 import cats.effect.IO
-import cats.effect.kernel.Resource
 import cats.syntax.either.*
 import endless.\/
 import endless.core.entity.Sharding
@@ -91,8 +90,8 @@ class ShardedAccountsSuite
           query: Transfer,
           branch: AccountID,
           otherBranches: AccountID*
-      ): Resource[IO, Transaction[IO, AccountID, Transfer, TransferFailure]] =
-        Resource.pure(new Transaction[IO, AccountID, Transfer, TransferFailure] {
+      ): IO[Transaction[IO, AccountID, Transfer, TransferFailure]] =
+        IO(new Transaction[IO, AccountID, Transfer, TransferFailure] {
           def query: IO[Transaction.Unknown.type \/ Transfer] = fail("should not be called")
           def branches: IO[Transaction.Unknown.type \/ Set[AccountID]] =
             fail("should not be called")
@@ -102,7 +101,8 @@ class ShardedAccountsSuite
             fail("should not be called")
         })
 
-      def get(id: TransferID): Resource[IO, Transaction[IO, AccountID, Transfer, TransferFailure]] =
-        fail("should not be called")
+      def get(id: TransferID): Transaction[IO, AccountID, Transfer, TransferFailure] = fail(
+        "should not be called"
+      )
     }
 }

--- a/lib/src/main/protobuf/endless/transaction/proto/model.proto
+++ b/lib/src/main/protobuf/endless/transaction/proto/model.proto
@@ -86,6 +86,10 @@ message Failed {
 
 message Unknown {}
 
-message TooLateToAbort {}
+message TooLateToAbort {
+  string message = 1;
+}
 
-message TransactionFailed {}
+message TransactionFailed {
+  string message = 1;
+}

--- a/lib/src/main/scala/endless/transaction/Coordinator.scala
+++ b/lib/src/main/scala/endless/transaction/Coordinator.scala
@@ -1,7 +1,5 @@
 package endless.transaction
 
-import cats.effect.kernel.Resource
-
 /** A coordinator allows for creating and recovering transactions of a certain type. Internally, it
   * implements the two-phase commit protocol to guarantee a final transaction state of either
   * committed or aborted.
@@ -19,9 +17,7 @@ import cats.effect.kernel.Resource
   */
 trait Coordinator[F[_], TID, BID, Q, R] {
 
-  /** Creates a new transaction with the given id, query and branches, and returns a handle to it
-    * wrapped in a `Resource`. Resource release leads to transaction abort if it is still pending
-    * (or a no-op if the transaction is already completed).
+  /** Creates a new transaction with the given id, query and branches.
     *
     * @note
     *   the transaction identifier must be unique and an exception will be raised in the target
@@ -42,14 +38,11 @@ trait Coordinator[F[_], TID, BID, Q, R] {
       query: Q,
       branch: BID,
       otherBranches: BID*
-  ): Resource[F, Transaction[F, BID, Q, R]]
+  ): F[Transaction[F, BID, Q, R]]
 
   /** Recovers a transaction with the given id. Can be used by recovering clients who lost the
     * handle to the transaction and that require further interaction with it, or to retrieve
     * information about past transactions.
-    *
-    * Resource release leads to transaction abort if it is still pending (or a no-op if the
-    * transaction is already completed).
     *
     * @note
     *   by default, pending transactions are recovered automatically upon coordinator startup
@@ -62,7 +55,7 @@ trait Coordinator[F[_], TID, BID, Q, R] {
     * @return
     *   handle to the transaction
     */
-  def get(id: TID): Resource[F, Transaction[F, BID, Q, R]]
+  def get(id: TID): Transaction[F, BID, Q, R]
 }
 
 object Coordinator {

--- a/lib/src/main/scala/endless/transaction/Transactor.scala
+++ b/lib/src/main/scala/endless/transaction/Transactor.scala
@@ -114,6 +114,7 @@ trait Transactor[F[_]] {
     type Alg[K[_]] = TransactionAlg[K, TID, BID, Q, R]
     type RepositoryAlg[K[_]] = Coordinator[K, TID, BID, Q, R]
     implicit val entityNameProvider: EntityNameProvider[TID] = () => transactionName
+    implicit val entityIDShow: Show[TID] = Show.show(implicitly[StringCodec[TID]].encode)
     implicit val protocol: CommandProtocol[TID, Alg] = new TransactionProtocol[TID, BID, Q, R]
     implicit val eventApplier: EventApplier[S, E] = new TransactionEventApplier[TID, BID, Q, R]
     deployer

--- a/lib/src/test/scala/endless/transaction/impl/Generators.scala
+++ b/lib/src/test/scala/endless/transaction/impl/Generators.scala
@@ -125,10 +125,10 @@ trait Generators {
   val alreadyExistsGen: Gen[TransactionCreator.AlreadyExists.type] =
     Gen.const(TransactionCreator.AlreadyExists)
   val unknownGen: Gen[Transaction.Unknown.type] = Gen.const(Transaction.Unknown)
-  val tooLateToAbortGen: Gen[Transaction.TooLateToAbort.type] =
-    Gen.const(Transaction.TooLateToAbort)
-  val transactionFailedGen: Gen[Transaction.TransactionFailed.type] =
-    Gen.const(Transaction.TransactionFailed)
+  val tooLateToAbortGen: Gen[Transaction.TooLateToAbort] =
+    Gen.alphaNumStr.map(Transaction.TooLateToAbort(_))
+  val transactionFailedGen: Gen[Transaction.TransactionFailed] =
+    Gen.alphaNumStr.map(Transaction.TransactionFailed(_))
 
   val abortErrorGen: Gen[Transaction.AbortError] = Gen.oneOf(
     unknownGen,
@@ -194,10 +194,10 @@ trait Generators {
     alreadyExistsGen
   )
   implicit val arbUnknown: Arbitrary[Transaction.Unknown.type] = Arbitrary(unknownGen)
-  implicit val arbTooLateToAbort: Arbitrary[Transaction.TooLateToAbort.type] = Arbitrary(
+  implicit val arbTooLateToAbort: Arbitrary[Transaction.TooLateToAbort] = Arbitrary(
     tooLateToAbortGen
   )
-  implicit val arbTransactionFailed: Arbitrary[Transaction.TransactionFailed.type] = Arbitrary(
+  implicit val arbTransactionFailed: Arbitrary[Transaction.TransactionFailed] = Arbitrary(
     transactionFailedGen
   )
   implicit val arbTransactionEvent: Arbitrary[TransactionEvent[TID, BID, Q, R]] = Arbitrary(

--- a/lib/src/test/scala/endless/transaction/impl/logic/TransactionEntityBehaviorSuite.scala
+++ b/lib/src/test/scala/endless/transaction/impl/logic/TransactionEntityBehaviorSuite.scala
@@ -132,9 +132,9 @@ class TransactionEntityBehaviorSuite
           .abort(reason)
           .run(Some(state))
           .map {
-            case Right((_, Left(Transaction.TooLateToAbort))) => ()
-            case Right((_, _))                                => fail("Unexpected")
-            case Left(error)                                  => fail(error)
+            case Right((_, Left(Transaction.TooLateToAbort(_)))) => ()
+            case Right((_, _))                                   => fail("Unexpected")
+            case Left(error)                                     => fail(error)
           }
     }
   }
@@ -158,9 +158,9 @@ class TransactionEntityBehaviorSuite
         .abort(reason)
         .run(Some(state))
         .map {
-          case Right((_, Left(Transaction.TransactionFailed))) => ()
-          case Right((_, _))                                   => fail("Unexpected")
-          case Left(error)                                     => fail(error)
+          case Right((_, Left(Transaction.TransactionFailed(_)))) => ()
+          case Right((_, _))                                      => fail("Unexpected")
+          case Left(error)                                        => fail(error)
         }
     }
   }


### PR DESCRIPTION
Instead of imposing a Resource-based API, make this optional. The transaction will progress on its own anyway, the resource wrapper is a convenience for aborting.