### PR TITLE
Funnel back the abort reason to the branch abort call

### DIFF
--- a/example/src/main/scala/endless/transaction/example/logic/TransferBranch.scala
+++ b/example/src/main/scala/endless/transaction/example/logic/TransferBranch.scala
@@ -9,6 +9,7 @@ import cats.syntax.show.*
 import cats.syntax.applicative.*
 import cats.conversions.all.*
 import endless.transaction.Branch
+import endless.transaction.Transaction.AbortReason
 import endless.transaction.example.algebra.Account
 import endless.transaction.example.algebra.Account.InsufficientFunds
 import endless.transaction.example.algebra.Accounts.TransferFailure
@@ -81,7 +82,7 @@ class TransferBranch[F[_]: Logger](accountID: AccountID, account: Account[F])(im
           pure
         )
 
-  def abort(transferID: TransferID): F[Unit] =
+  def abort(transferID: TransferID, reason: AbortReason[TransferFailure]): F[Unit] =
     Logger[F].debug(show"Aborting transfer $transferID for account $accountID") >>
       EitherT(
         account

--- a/example/src/test/scala/endless/transaction/example/logic/TransferBranchSuite.scala
+++ b/example/src/test/scala/endless/transaction/example/logic/TransferBranchSuite.scala
@@ -9,6 +9,7 @@ import endless.transaction.example.data.Transfer.TransferID
 import endless.transaction.example.Generators
 import cats.syntax.either.*
 import endless.transaction.Branch
+import endless.transaction.Transaction.AbortReason
 import endless.transaction.example.algebra.Accounts.TransferFailure
 import endless.transaction.example.helpers.RetryHelpers.RetryParameters
 import endless.transaction.helpers.LogMessageAssertions
@@ -243,8 +244,8 @@ class TransferBranchSuite
           }
         }
       )
-      assertIO(destinationBranch.abort(transferID), ()) >> assertIO(
-        originBranch.abort(transferID),
+      assertIO(destinationBranch.abort(transferID, AbortReason.Timeout), ()) >> assertIO(
+        originBranch.abort(transferID, AbortReason.Timeout),
         ()
       ) >> testLogger.assertLogsDebug
     }
@@ -348,7 +349,7 @@ class TransferBranchSuite
           }
         )
         _ <- assertIO(
-          branch.abort(transferID),
+          branch.abort(transferID, AbortReason.Timeout),
           ()
         )
         _ <- testLogger.assertLogsWarn

--- a/lib/src/main/scala/endless/transaction/impl/logic/TransactionSideEffect.scala
+++ b/lib/src/main/scala/endless/transaction/impl/logic/TransactionSideEffect.scala
@@ -128,7 +128,7 @@ private[transaction] final class TransactionSideEffect[
         state: Aborting[TID, BID, Q, R]
     )(branchID: BID, branch: Branch[F, TID, Q, R]) = {
       branch
-        .abort(state.id)
+        .abort(state.id, state.reason)
         .flatMap(_ =>
           self
             .branchAborted(branchID)


### PR DESCRIPTION
So that differentiated behavior can be added to the abort logic